### PR TITLE
CM-30407 - Use CLI in onedir mode on macOS

### DIFF
--- a/src/main/kotlin/com/cycode/plugin/Consts.kt
+++ b/src/main/kotlin/com/cycode/plugin/Consts.kt
@@ -3,13 +3,27 @@ package com.cycode.plugin
 import com.intellij.openapi.application.PathManager
 import com.intellij.openapi.util.SystemInfo
 
+private fun getDefaultCliPath(): String {
+    if (SystemInfo.isWindows) {
+        return "${Consts.PLUGIN_PATH}/cycode.exe"
+    }
+
+    if (SystemInfo.isMac) {
+        // on macOS, we are always using onedir mode because of gatekeeper
+        return "${Consts.PLUGIN_PATH}/cycode-cli/cycode-cli"
+    }
+
+    return "${Consts.PLUGIN_PATH}/cycode"
+}
+
+
 class Consts {
     companion object {
         val PLUGIN_PATH = PathManager.getPluginsPath() + "/cycode-intellij-platform-plugin"
-        val DEFAULT_CLI_PATH = "$PLUGIN_PATH/cycode" + if (SystemInfo.isWindows) ".exe" else ""
+        val DEFAULT_CLI_PATH = getDefaultCliPath()
         const val CLI_GITHUB_ORG = "cycodehq"
         const val CLI_GITHUB_REPO = "cycode-cli"
-        const val CLI_GITHUB_TAG = "v1.7.0"
+        const val CLI_GITHUB_TAG = "v1.7.1"
         const val CLI_CHECK_NEW_VERSION_EVERY_SEC = 24 * 60 * 60 // 24 hours
         const val PLUGIN_AUTO_SAVE_FLUSH_INITIAL_DELAY_SEC = 0L
         const val PLUGIN_AUTO_SAVE_FLUSH_DELAY_SEC = 5L

--- a/src/main/kotlin/com/cycode/plugin/cli/CliWrapper.kt
+++ b/src/main/kotlin/com/cycode/plugin/cli/CliWrapper.kt
@@ -13,7 +13,6 @@ import com.intellij.execution.process.ProcessListener
 import com.intellij.execution.process.ProcessOutputTypes
 import com.intellij.openapi.diagnostic.thisLogger
 import com.intellij.openapi.util.Key
-import com.intellij.openapi.util.SystemInfo
 import com.intellij.util.io.BaseOutputReader
 import java.io.File
 import java.nio.charset.Charset

--- a/src/main/kotlin/com/cycode/plugin/services/CycodePersistentStateService.kt
+++ b/src/main/kotlin/com/cycode/plugin/services/CycodePersistentStateService.kt
@@ -18,6 +18,7 @@ class CycodePersistentStateService : PersistentStateComponent<CycodePersistentSt
     var cliAuthed: Boolean = false
     var cliVer: String? = null
     var cliHash: String? = null
+    var cliDirHashes: Map<String, String>? = null
     var cliLastUpdateCheckedAt: Long? = null
 
     override fun getState(): CycodePersistentStateService {

--- a/src/main/kotlin/com/cycode/plugin/services/CycodeService.kt
+++ b/src/main/kotlin/com/cycode/plugin/services/CycodeService.kt
@@ -28,9 +28,9 @@ class CycodeService(val project: Project) {
                 if (
                     pluginSettings.cliPath == Consts.DEFAULT_CLI_PATH &&
                     pluginSettings.cliAutoManaged &&
-                    cliDownloadService.shouldDownloadCli(pluginSettings.cliPath)
+                    cliDownloadService.shouldDownloadCli()
                 ) {
-                    cliDownloadService.downloadCli(pluginSettings.cliPath)
+                    cliDownloadService.downloadCli()
                     thisLogger().info("CLI was successfully downloaded/updated")
                 }
 

--- a/src/main/kotlin/com/cycode/plugin/services/DownloadService.kt
+++ b/src/main/kotlin/com/cycode/plugin/services/DownloadService.kt
@@ -37,6 +37,10 @@ class DownloadService {
         return null
     }
 
+    fun downloadFile(url: String, checksum: String?, localPath: File): File? {
+        return downloadFile(url, checksum, localPath.toString())
+    }
+
     fun downloadFile(url: String, checksum: String?, localPath: String): File? {
         thisLogger().warn("Downloading $url with checksum $checksum")
         thisLogger().warn("Expecting to download to $localPath")

--- a/src/main/kotlin/com/cycode/plugin/utils/FileChecksum.kt
+++ b/src/main/kotlin/com/cycode/plugin/utils/FileChecksum.kt
@@ -47,3 +47,30 @@ fun verifyFileChecksum(file: File, sha256Checksum: String): Boolean {
 fun verifyFileChecksum(file: String, sha256Checksum: String): Boolean {
     return verifyFileChecksum(File(file), sha256Checksum)
 }
+
+fun verifyDirContentChecksums(dir: String, checksumDb: Map<String, String>): Boolean {
+    for ((filename, checksum) in checksumDb) {
+        val filePath = File(dir, filename)
+        if (!verifyFileChecksum(filePath, checksum)) {
+            return false
+        }
+    }
+
+    return true
+}
+
+
+fun parseOnedirChecksumDb(rawChecksumDb: String): Map<String, String> {
+    val checksums = mutableMapOf<String, String>()
+    val lines = rawChecksumDb.split("\n")
+    for (line in lines) {
+        val parts = line.split(" ")
+        if (parts.size != 2) {
+            continue
+        }
+
+        val (checksum, filename) = parts
+        checksums[filename] = checksum
+    }
+    return checksums
+}

--- a/src/main/kotlin/com/cycode/plugin/utils/Zip.kt
+++ b/src/main/kotlin/com/cycode/plugin/utils/Zip.kt
@@ -1,0 +1,21 @@
+package com.cycode.plugin.utils
+
+import java.io.File
+import java.util.zip.ZipFile
+
+
+fun unzip(zipFile: File, destDir: String) {
+    ZipFile(zipFile).use { zip ->
+        zip.entries().asSequence().forEach { entry ->
+            zip.getInputStream(entry).use { input ->
+                val destFile = File(destDir, entry.name)
+                if (entry.isDirectory) {
+                    destFile.mkdirs()
+                } else {
+                    destFile.parentFile.mkdirs()
+                    input.copyTo(destFile.outputStream())
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
tl;dr performance fix of macOS

we are using onedir mode (pyinstaller) on macOS because of the gatekeeper that verifies the executable each run which is the reason for the long cold start (up to 12 seconds)

also, it brings support of macOS ARM CLI

~~we can't merge it because of issues with multiprocessing in packaged CLI~~
CLI has been fixed

More info about performance issues of onefile mode on macOS: https://github.com/orgs/pyinstaller/discussions/8167