### PR TITLE
CM-27501 - Add SCA support

### DIFF
--- a/src/main/kotlin/com/cycode/plugin/annotators/CycodeAnnotator.kt
+++ b/src/main/kotlin/com/cycode/plugin/annotators/CycodeAnnotator.kt
@@ -3,6 +3,8 @@ package com.cycode.plugin.annotators
 import com.cycode.plugin.CycodeBundle
 import com.cycode.plugin.cli.CliResult
 import com.cycode.plugin.cli.CliScanType
+import com.cycode.plugin.cli.getPackageFileForLockFile
+import com.cycode.plugin.cli.isSupportedLockFile
 import com.cycode.plugin.intentions.CycodeIgnoreIntentionQuickFix
 import com.cycode.plugin.intentions.CycodeIgnoreType
 import com.cycode.plugin.services.scanResults
@@ -35,23 +37,15 @@ class CycodeAnnotator : DumbAware, ExternalAnnotator<PsiFile, Unit>() {
         }
     }
 
-    private fun validateTextRange(scanType: CliScanType, textRange: TextRange, psiFile: PsiFile): Boolean {
-        if (textRange.endOffset > psiFile.text.length || textRange.startOffset < 0) {
-            // check if text range fits in file
-
-            // case: row with detections has been deleted, but detection is still in the local results DB
-            thisLogger().warn("Text range of detection is out of file bounds")
-            return false
-        }
-
+    private fun validateSecretTextRange(textRange: TextRange, psiFile: PsiFile): Boolean {
         val detectedSubstr = psiFile.text.substring(textRange.startOffset, textRange.endOffset)
-        val detectedSegment = scanResults.getDetectedSegment(scanType, textRange)
+        val detectedSegment = scanResults.getDetectedSegment(CliScanType.Secret, textRange)
         if (detectedSegment == null) {
-            scanResults.saveDetectedSegment(scanType, textRange, detectedSubstr)
+            scanResults.saveDetectedSegment(CliScanType.Secret, textRange, detectedSubstr)
         } else if (detectedSegment != detectedSubstr) {
             // case: the code has been added or deleted before the detection
             thisLogger().warn(
-                "Text range of detection has been shifted. " +
+                "[Secret] Text range of detection has been shifted. " +
                         "Annotation is not relevant to this state of the file content anymore"
             )
             return false
@@ -60,8 +54,36 @@ class CycodeAnnotator : DumbAware, ExternalAnnotator<PsiFile, Unit>() {
         return true
     }
 
+    private fun validateScaTextRange(textRange: TextRange, psiFile: PsiFile, expectedPackageName: String): Boolean {
+        // text range is dynamic and calculated from the line number,
+        // so we can't use the same validation as for secrets
+        // instead, we check if the package name is still in the text range
+        val detectedSubstr = psiFile.text.substring(textRange.startOffset, textRange.endOffset)
+        if (!detectedSubstr.contains(expectedPackageName)) {
+            thisLogger().warn(
+                "[SCA] Text range of detection has been shifted. " +
+                        "Annotation is not relevant to this state of the file content anymore"
+            )
+            return false
+        }
+
+        return true
+    }
+
+    private fun validateTextRange(textRange: TextRange, psiFile: PsiFile): Boolean {
+        if (textRange.endOffset > psiFile.text.length || textRange.startOffset < 0) {
+            // check if text range fits in file
+
+            // case: row with detections has been deleted, but detection is still in the local results DB
+            thisLogger().warn("Text range of detection is out of file bounds")
+            return false
+        }
+
+        return true
+    }
+
     private fun applyAnnotationsForSecrets(psiFile: PsiFile, holder: AnnotationHolder) {
-        val latestScanResult = scanResults.getSecretsResults()
+        val latestScanResult = scanResults.getSecretResults()
         if (latestScanResult !is CliResult.Success) {
             return
         }
@@ -79,7 +101,7 @@ class CycodeAnnotator : DumbAware, ExternalAnnotator<PsiFile, Unit>() {
                 detectionDetails.startPosition + detectionDetails.length
             )
 
-            if (!validateTextRange(CliScanType.Secret, textRange, psiFile)) {
+            if (!validateTextRange(textRange, psiFile) || !validateSecretTextRange(textRange, psiFile)) {
                 return@forEach
             }
 
@@ -118,5 +140,71 @@ class CycodeAnnotator : DumbAware, ExternalAnnotator<PsiFile, Unit>() {
         }
     }
 
-    private fun applyAnnotationsForSca(psiFile: PsiFile, holder: AnnotationHolder) {}
+    private fun applyAnnotationsForSca(psiFile: PsiFile, holder: AnnotationHolder) {
+        val latestScanResult = scanResults.getScaResults()
+        if (latestScanResult !is CliResult.Success) {
+            return
+        }
+
+        val relevantDetections = latestScanResult.result.detections.filter { detection ->
+            detection.detectionDetails.getFilepath() == psiFile.virtualFile.path
+        }
+
+        relevantDetections.forEach { detection ->
+            val severity = convertSeverity(detection.severity)
+
+            // SCA doesn't provide start and end positions, so we have to calculate them from the line number
+            val line = detection.detectionDetails.lineInFile - 1
+            val startOffset = psiFile.text.lines().take(line).sumOf { it.length + 1 }
+            val endOffset = startOffset + psiFile.text.lines()[line].length
+
+            val detectionDetails = detection.detectionDetails
+            val textRange = TextRange(startOffset, endOffset)
+
+            if (!validateTextRange(textRange, psiFile) || !validateScaTextRange(
+                    textRange,
+                    psiFile,
+                    detectionDetails.packageName
+                )
+            ) {
+                return@forEach
+            }
+
+            val title = CycodeBundle.message(
+                "scaAnnotationTitle",
+                detectionDetails.packageName,
+                detectionDetails.packageVersion,
+                // using the message as fallback for non-premise license detections
+                detectionDetails.vulnerabilityDescription ?: detection.message
+            )
+
+            var firstPatchedVersionMessage = ""
+            if (detectionDetails.alert?.firstPatchedVersion != null) {
+                firstPatchedVersionMessage = CycodeBundle.message(
+                    "scaAnnotationTooltipFirstPatchedVersion",
+                    detectionDetails.alert.firstPatchedVersion
+                )
+            }
+
+            var lockFileNote = ""
+            if (isSupportedLockFile(psiFile.virtualFile.name)) {
+                val packageFileName = getPackageFileForLockFile(psiFile.virtualFile.name)
+                lockFileNote = CycodeBundle.message("scaAnnotationTooltipLockFileNote", packageFileName)
+            }
+
+            val tooltip = CycodeBundle.message(
+                "scaAnnotationTooltip",
+                detection.severity,
+                firstPatchedVersionMessage,
+                detection.message,
+                detection.detectionRuleId,
+                lockFileNote,
+            )
+            holder.newAnnotation(severity, title)
+                .range(textRange)
+                .tooltip(tooltip)
+                // TODO(MarshalX): add quick fix for SCA (ignoring)
+                .create()
+        }
+    }
 }

--- a/src/main/kotlin/com/cycode/plugin/cli/CliWrapper.kt
+++ b/src/main/kotlin/com/cycode/plugin/cli/CliWrapper.kt
@@ -97,12 +97,14 @@ class CliWrapper(val executablePath: String, val workDirectory: String? = null) 
             val result: T = mapper.readValue(stdout)
             return CliResult.Success(result)
         } catch (e: Exception) {
+            thisLogger().warn("Failed to parse success CLI output: $stdout", e)
+
             try {
                 // FIXME(MarshalX): probably CLI not standardized error format for the whole project yet
                 val result: CliError = mapper.readValue(stdout)
                 return CliResult.Error(result)
             } catch (e: Exception) {
-                thisLogger().error("Failed to parse CLI output: $stdout", e)
+                thisLogger().error("Failed to parse ANY CLI output: $stdout", e)
             }
 
             return CliResult.Panic(exitCode, stderr)

--- a/src/main/kotlin/com/cycode/plugin/cli/ScaHelpers.kt
+++ b/src/main/kotlin/com/cycode/plugin/cli/ScaHelpers.kt
@@ -1,0 +1,86 @@
+package com.cycode.plugin.cli
+
+// keep in lowercase.
+// source: https://github.com/cycodehq/cycode-cli/blob/ec8333707ab2590518fd0f36454c8636ccbf1061/cycode/cli/consts.py#L50-L82
+private val SCA_CONFIGURATION_SCAN_SUPPORTED_FILES: List<String> = listOf(
+    "cargo.lock",
+    "cargo.toml",
+    "composer.json",
+    "composer.lock",
+    "go.sum",
+    "go.mod",
+    // "gopkg.toml", // FIXME(MarshalX): missed in CLI?
+    "gopkg.lock",
+    "pom.xml",
+    "build.gradle",
+    "gradle.lockfile",
+    "build.gradle.kts",
+    "package.json",
+    "package-lock.json",
+    "yarn.lock",
+    "npm-shrinkwrap.json",
+    "packages.config",
+    "project.assets.json",
+    "packages.lock.json",
+    "nuget.config",
+    ".csproj",
+    "gemfile",
+    "gemfile.lock",
+    "build.sbt",
+    "build.scala",
+    "build.sbt.lock",
+    "pyproject.toml",
+    "poetry.lock",
+    "pipfile",
+    "pipfile.lock",
+    "requirements.txt",
+    "setup.py",
+    "mix.exs",
+    "mix.lock",
+)
+
+private val SCA_CONFIGURATION_SCAN_LOCK_FILE_TO_PACKAGE_FILE: Map<String, String> = mapOf(
+    "cargo.lock" to "cargo.toml",
+    "composer.lock" to "composer.json",
+    "go.sum" to "go.mod",
+    "gopkg.lock" to "gopkg.toml",
+    "gradle.lockfile" to "build.gradle",
+    "package-lock.json" to "package.json",
+    "yarn.lock" to "package.json",
+    "packages.lock.json" to "nuget.config",
+    "gemfile.lock" to "gemfile",
+    "build.sbt.lock" to "build.sbt", // and build.scala?
+    "poetry.lock" to "pyproject.toml",
+    "pipfile.lock" to "pipfile",
+    "mix.lock" to "mix.exs",
+)
+
+private val SCA_CONFIGURATION_SCAN_SUPPORTED_LOCK_FILES: List<String> =
+    SCA_CONFIGURATION_SCAN_LOCK_FILE_TO_PACKAGE_FILE.keys.toList()
+
+fun isSupportedPackageFile(filename: String): Boolean {
+    val lowercaseFilename = filename.toLowerCase()
+    SCA_CONFIGURATION_SCAN_SUPPORTED_FILES.forEach {
+        if (lowercaseFilename.endsWith(it)) {
+            return true
+        }
+    }
+
+    return false
+}
+
+fun isSupportedLockFile(filename: String): Boolean {
+    val lowercaseFilename = filename.toLowerCase()
+    SCA_CONFIGURATION_SCAN_SUPPORTED_LOCK_FILES.forEach {
+        if (lowercaseFilename.endsWith(it)) {
+            return true
+        }
+    }
+
+    return false
+}
+
+fun getPackageFileForLockFile(filename: String): String {
+    val lowercaseFilename = filename.toLowerCase()
+    return SCA_CONFIGURATION_SCAN_LOCK_FILE_TO_PACKAGE_FILE.getOrDefault(lowercaseFilename, "package")
+}

--- a/src/main/kotlin/com/cycode/plugin/cli/models/scanResult/sca/ScaDetection.kt
+++ b/src/main/kotlin/com/cycode/plugin/cli/models/scanResult/sca/ScaDetection.kt
@@ -1,0 +1,10 @@
+package com.cycode.plugin.cli.models.scanResult.sca
+
+data class ScaDetection(
+    val message: String,
+    val detectionDetails: ScaDetectionDetails,
+    val severity: String,
+    val type: String,
+    val detectionRuleId: String,
+    val detectionTypeId: String,
+)

--- a/src/main/kotlin/com/cycode/plugin/cli/models/scanResult/sca/ScaDetectionDetails.kt
+++ b/src/main/kotlin/com/cycode/plugin/cli/models/scanResult/sca/ScaDetectionDetails.kt
@@ -1,0 +1,22 @@
+package com.cycode.plugin.cli.models.scanResult.sca
+
+import com.cycode.plugin.cli.models.scanResult.ScanDetectionDetailsBase
+
+data class ScaDetectionDetails(
+    val fileName: String,
+    val startPosition: Int,
+    val endPosition: Int,
+    val line: Int,
+    val lineInFile: Int,
+    val dependencyPaths: String,
+    val licence: String?,
+    val packageName: String,
+    val packageVersion: String,
+    val vulnerabilityDescription: String?,
+    val vulnerabilityId: String?,
+    val alert: ScaDetectionDetailsAlert?,
+) : ScanDetectionDetailsBase {
+    override fun getFilepath(): String {
+        return fileName
+    }
+}

--- a/src/main/kotlin/com/cycode/plugin/cli/models/scanResult/sca/ScaDetectionDetailsAlert.kt
+++ b/src/main/kotlin/com/cycode/plugin/cli/models/scanResult/sca/ScaDetectionDetailsAlert.kt
@@ -1,0 +1,9 @@
+package com.cycode.plugin.cli.models.scanResult.sca
+
+data class ScaDetectionDetailsAlert(
+    val severity: String,
+    val summary: String,
+    val description: String,
+    val vulnerableRequirements: String?,
+    val firstPatchedVersion: String?,
+)

--- a/src/main/kotlin/com/cycode/plugin/cli/models/scanResult/sca/ScaScanResult.kt
+++ b/src/main/kotlin/com/cycode/plugin/cli/models/scanResult/sca/ScaScanResult.kt
@@ -1,0 +1,8 @@
+package com.cycode.plugin.cli.models.scanResult.sca
+
+import com.cycode.plugin.cli.models.CliError
+
+data class ScaScanResult(
+    val detections: List<ScaDetection>,
+    val errors: List<CliError>,
+)

--- a/src/main/kotlin/com/cycode/plugin/cli/models/scanResult/secret/SecretDetection.kt
+++ b/src/main/kotlin/com/cycode/plugin/cli/models/scanResult/secret/SecretDetection.kt
@@ -5,6 +5,6 @@ data class SecretDetection(
     val detectionDetails: SecretDetectionDetails,
     val severity: String,
     val type: String,
-    val detectionRuleId: String,  // TODO(MarshalX): actually UUID. annotate?
-    val detectionTypeId: String,  // TODO(MarshalX): actually UUID. annotate?
+    val detectionRuleId: String,  // UUID
+    val detectionTypeId: String,  // UUID
 )

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/scanContentTab/ScanContentTab.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/scanContentTab/ScanContentTab.kt
@@ -40,17 +40,26 @@ class ScanContentTab : Component<CycodeService>() {
                     insets = JBUI.insetsBottom(10)
                     fill = GridBagConstraints.HORIZONTAL
                 })
+                add(JButton(CycodeBundle.message("scanTabScaBtn")).apply {
+                    addActionListener {
+                        service.startScaScanForCurrentProject()
+                    }
+                }, GridBagConstraints().apply {
+                    gridy = 3
+                    insets = JBUI.insetsBottom(10)
+                    fill = GridBagConstraints.HORIZONTAL
+                })
                 add(add(JPanel().apply {
                     add(createClickableLabel(CycodeBundle.message("scanTabOnSaveTip")))
                 }), GridBagConstraints().apply {
-                    gridy = 3
+                    gridy = 4
                     insets = JBUI.insetsBottom(10)
                     anchor = GridBagConstraints.NORTHWEST
                 })
                 add(add(JPanel().apply {
                     add(createClickableLabel(CycodeBundle.message("howToUseLabel")))
                 }), GridBagConstraints().apply {
-                    gridy = 4
+                    gridy = 5
                     insets = JBUI.insetsBottom(10)
                     anchor = GridBagConstraints.NORTHWEST
                 })

--- a/src/main/resources/messages/CycodeBundle.properties
+++ b/src/main/resources/messages/CycodeBundle.properties
@@ -4,6 +4,10 @@ name=Cycode
 secretsAnnotationTitle=Cycode: {0}. {1}
 secretsAnnotationTooltip=<html>Severity: {0}<br>{1}: {2}<br>Rule ID: {3}<br>In file: {4}<br>Secret SHA: {5}{6}</html>
 secretsAnnotationTooltipCompanyGuideline=<br>Company Guideline: {0}
+scaAnnotationTitle=Cycode: {0}@{1} - {2}
+scaAnnotationTooltip=<html>Severity: {0}<br>{1}<br>{2}<br>Rule ID: {3}{4}</html>
+scaAnnotationTooltipFirstPatchedVersion=First patched version: {0}
+scaAnnotationTooltipLockFileNote=<br><br>Avoid manual packages upgrades in lock files. Update the {0} file and re-generate the lock file.
 # notifications
 notificationGroupId=Cycode
 notificationTitle=Cycode
@@ -12,6 +16,7 @@ authErrorNotification=Authentication failed. Please try again
 missingCStandardLibraryErrorNotification=Plugin requires C standard library (libc/glibc) to be installed. Please install it and restart the IDE.
 unknownErrorNotification=Unknown error occurred. Please try again
 noOpenFileErrorNotification=Cycode scans the file that is currently opened. Please open a file and try again
+noProjectRootErrorNotification=Cycode scans the project that is currently opened. Please open a project and try again
 scanFileResultNotification=Cycode has detected {0} {1} issues in your file. Check out your "Problems" tab to analyze.
 scanFileNoResultNotification=No {0} issues were found.
 openProblemsTabAction=Open "Problems" tab
@@ -26,10 +31,12 @@ scanTabTitleLabel=Ready to scan.
 scanTabPreButtonsLabel=Open a file for editing and then hit the button:
 scanTabOnSaveTip=To easily scan your files, enable Scan on Save in settings.
 scanTabSecretsBtn=Scan for hardcoded secrets
+scanTabScaBtn=Scan for package vulnerabilities
 # progress indicators
 pluginLoading=Cycode is loading...
 authProcessing=Start auth...
-fileScanning=Cycode is scanning files...
+secretScanning=Cycode is scanning files for hardcoded secrets...
+scaScanning=Cycode is scanning files for package vulnerabilities...
 ignoresApplying=Cycode is applying ignores...
 # settings menu
 settingsCliSectionTitle=Cycode CLI settings


### PR DESCRIPTION
limitations:
- we can't annotate .lock, .exs, etc files because of a lack of registered languages 
- we can't select an accurate text range (same as in VS code) because BE returns only a line in the file

leftovers:
- ignoring quick fixes (I'll bring it as a separate PR)

demo:
<img width="1278" alt="image" src="https://github.com/cycodehq/intellij-platform-plugin/assets/15520314/7f94b18a-84b0-458e-98ef-37693dfd1f88">
