### PR TITLE
CM-33449 - Add Action Toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ## [Unreleased]
 
-## [1.5.0] - 2024-03-XX
+## [1.5.0] - 2024-03-13
 
 - Add SCA Violation Card
+- Add action toolbar to the Cycode tab
 - Add the on-demand scan of an entire project for Secrets
 
 ## [1.4.0] - 2024-02-28

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/CycodeContentTab.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/CycodeContentTab.kt
@@ -2,13 +2,20 @@ package com.cycode.plugin.components.toolWindow
 
 import com.cycode.plugin.components.toolWindow.components.treeView.TreeView
 import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.SimpleToolWindowPanel
 import javax.swing.JPanel
 
-class CycodeContentTab(project: Project) {
+class CycodeContentTab(project: Project) : SimpleToolWindowPanel(false, false) {
     private val treeView = TreeView(project)
+
+    init {
+        setContent(treeView)
+    }
 
     fun updateContent(rightPanel: JPanel): JPanel {
         treeView.refreshTree()
         return treeView.replaceRightPanel(rightPanel)
     }
+
+    fun getTreeView() = treeView
 }

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/CycodeToolWindowFactory.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/CycodeToolWindowFactory.kt
@@ -1,6 +1,7 @@
 package com.cycode.plugin.components.toolWindow
 
 import com.cycode.plugin.components.toolWindow.components.authContentTab.AuthContentTab
+import com.cycode.plugin.components.toolWindow.components.cycodeActionToolBar.CycodeActionToolbar
 import com.cycode.plugin.components.toolWindow.components.loadingContentTab.LoadingContentTab
 import com.cycode.plugin.components.toolWindow.components.scanContentTab.ScanContentTab
 import com.cycode.plugin.icons.PluginIcons
@@ -30,8 +31,12 @@ class CycodeToolWindowFactory : DumbAware, ToolWindowFactory {
         val contentTab = CycodeContentTab(project)
         TabManager.addTab(project, contentTab)
 
+        CycodeActionToolbar().attachActionToolbar(contentTab)
+
         val initRightPanel = getRightPanelDependingOnState(project)
-        val toolWindowContent = createToolWindowContent(contentTab.updateContent(initRightPanel))
+        contentTab.updateContent(initRightPanel)
+
+        val toolWindowContent = createToolWindowContent(contentTab)
         toolWindow.contentManager.addContent(toolWindowContent)
 
         Disposer.register(service, toolWindowContent)
@@ -66,7 +71,7 @@ private fun createToolWindowContent(component: JPanel): Content {
     return ContentFactory.SERVICE.getInstance().createContent(component, null, false)
 }
 
-private fun getRightPanelDependingOnState(project: Project): JPanel {
+fun getRightPanelDependingOnState(project: Project): JPanel {
     val service = cycode(project)
     val pluginState = pluginState()
 

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/ActionToolBar.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/ActionToolBar.kt
@@ -1,0 +1,36 @@
+package com.cycode.plugin.components.toolWindow.components.cycodeActionToolBar
+
+import com.cycode.plugin.CycodeBundle
+import com.cycode.plugin.components.toolWindow.CycodeContentTab
+import com.cycode.plugin.components.toolWindow.components.cycodeActionToolBar.actions.*
+import com.intellij.openapi.actionSystem.ActionManager
+import com.intellij.openapi.actionSystem.ActionToolbar
+import com.intellij.openapi.actionSystem.DefaultActionGroup
+
+class CycodeActionToolbar {
+    fun attachActionToolbar(contentTab: CycodeContentTab): ActionToolbar {
+        val actionGroup = DefaultActionGroup().apply {
+            add(HomeAction.create(contentTab))
+            addSeparator()
+            add(ExpandAllAction.create(contentTab))
+            add(CollapseAllAction.create(contentTab))
+            addSeparator()
+            add(FilterBySeverityAction.create(contentTab, "Critical"))
+            add(FilterBySeverityAction.create(contentTab, "High"))
+            add(FilterBySeverityAction.create(contentTab, "Medium"))
+            add(FilterBySeverityAction.create(contentTab, "Low"))
+            addSeparator()
+            add(ClearAction.create(contentTab))
+            addSeparator()
+            add(SettingsAction.create(contentTab))
+        }
+
+        val toolbar = ActionManager.getInstance().createActionToolbar(
+            CycodeBundle.message("toolbarId"), actionGroup, true
+        )
+        toolbar.setTargetComponent(contentTab)
+        contentTab.toolbar = toolbar.component
+
+        return toolbar
+    }
+}

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/ActionToolBar.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/ActionToolBar.kt
@@ -12,6 +12,8 @@ class CycodeActionToolbar {
         val actionGroup = DefaultActionGroup().apply {
             add(HomeAction.create(contentTab))
             addSeparator()
+            add(RunAllAction.create(contentTab))
+            addSeparator()
             add(ExpandAllAction.create(contentTab))
             add(CollapseAllAction.create(contentTab))
             addSeparator()
@@ -23,6 +25,7 @@ class CycodeActionToolbar {
             add(ClearAction.create(contentTab))
             addSeparator()
             add(SettingsAction.create(contentTab))
+            add(HelpAction.create(contentTab))
         }
 
         val toolbar = ActionManager.getInstance().createActionToolbar(

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/ClearAction.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/ClearAction.kt
@@ -1,0 +1,32 @@
+package com.cycode.plugin.components.toolWindow.components.cycodeActionToolBar.actions
+
+import com.cycode.plugin.CycodeBundle
+import com.cycode.plugin.components.toolWindow.CycodeContentTab
+import com.cycode.plugin.services.scanResults
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import java.util.function.Supplier
+
+class ClearAction(private val contentTab: CycodeContentTab) :
+    DumbAwareAction(Supplier { CycodeBundle.message("toolbarClearAction") }, AllIcons.Actions.GC) {
+    companion object {
+        fun create(contentTab: CycodeContentTab): ClearAction {
+            return ClearAction(contentTab)
+        }
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        scanResults(project).clear()
+        contentTab.getTreeView().refreshTree()
+        DaemonCodeAnalyzer.getInstance(project).restart()
+    }
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabled = e.project != null &&
+                !e.project!!.isDisposed &&
+                scanResults(e.project!!).hasResults()
+    }
+}

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/CollapseAllAction.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/CollapseAllAction.kt
@@ -1,0 +1,18 @@
+package com.cycode.plugin.components.toolWindow.components.cycodeActionToolBar.actions
+
+import com.cycode.plugin.components.toolWindow.CycodeContentTab
+import com.intellij.ide.CommonActionsManager
+import com.intellij.ide.DefaultTreeExpander
+import com.intellij.openapi.actionSystem.AnAction
+
+class CollapseAllAction {
+    companion object {
+        fun create(contentTab: CycodeContentTab): AnAction {
+            val tree = contentTab.getTreeView().getTree()
+            val treeExpander = DefaultTreeExpander(tree)
+
+            val commonActionsManager = CommonActionsManager.getInstance()
+            return commonActionsManager.createCollapseAllAction(treeExpander, tree)
+        }
+    }
+}

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/ExpandAllAction.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/ExpandAllAction.kt
@@ -1,0 +1,18 @@
+package com.cycode.plugin.components.toolWindow.components.cycodeActionToolBar.actions
+
+import com.cycode.plugin.components.toolWindow.CycodeContentTab
+import com.intellij.ide.CommonActionsManager
+import com.intellij.ide.DefaultTreeExpander
+import com.intellij.openapi.actionSystem.AnAction
+
+class ExpandAllAction {
+    companion object {
+        fun create(contentTab: CycodeContentTab): AnAction {
+            val tree = contentTab.getTreeView().getTree()
+            val treeExpander = DefaultTreeExpander(tree)
+
+            val commonActionsManager = CommonActionsManager.getInstance()
+            return commonActionsManager.createExpandAllAction(treeExpander, tree)
+        }
+    }
+}

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/FilterBySeverityAction.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/FilterBySeverityAction.kt
@@ -1,0 +1,69 @@
+package com.cycode.plugin.components.toolWindow.components.cycodeActionToolBar.actions
+
+import com.cycode.plugin.CycodeBundle
+import com.cycode.plugin.components.toolWindow.CycodeContentTab
+import com.cycode.plugin.icons.PluginIcons
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.ToggleAction
+import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.project.Project
+import java.util.function.Supplier
+
+private class SeverityFilterManager {
+    // FIXME(MarshalX): remove closed projects?
+
+    companion object {
+        val INSTANCE = SeverityFilterManager()
+    }
+
+    private val severityFilterStates = mutableMapOf<Project, SeverityFilterState>()
+
+    fun getOrCreateState(project: Project): SeverityFilterState {
+        return severityFilterStates.getOrPut(project) { SeverityFilterState() }
+    }
+}
+
+
+private class SeverityFilterState {
+    private val selectedFilters = mutableMapOf<String, Boolean>()
+
+    fun setState(filter: String, selected: Boolean) {
+        selectedFilters[filter.toLowerCase()] = selected
+    }
+
+    fun getState(filter: String): Boolean {
+        // by default, all filters are selected
+        return selectedFilters.getOrDefault(filter.toLowerCase(), true)
+    }
+
+    fun exportState(): Map<String, Boolean> {
+        return selectedFilters
+    }
+}
+
+class FilterBySeverityAction(private val contentTab: CycodeContentTab, private val severity: String) :
+    ToggleAction(
+        Supplier { CycodeBundle.message("toolbarFilterBySeverityAction", severity) },
+        PluginIcons.getSeverityIcon(severity)
+    ),
+    DumbAware {
+    companion object {
+        fun create(contentTab: CycodeContentTab, severity: String): FilterBySeverityAction {
+            return FilterBySeverityAction(contentTab, severity)
+        }
+    }
+
+    override fun isSelected(e: AnActionEvent): Boolean {
+        val project = e.project ?: return false
+        val stateManager = SeverityFilterManager.INSTANCE.getOrCreateState(project)
+        return stateManager.getState(severity)
+    }
+
+    override fun setSelected(e: AnActionEvent, state: Boolean) {
+        val project = e.project ?: return
+        val stateManager = SeverityFilterManager.INSTANCE.getOrCreateState(project)
+        stateManager.setState(severity, state)
+
+        contentTab.getTreeView().updateSeverityFilter(stateManager.exportState())
+    }
+}

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/HelpAction.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/HelpAction.kt
@@ -1,0 +1,26 @@
+package com.cycode.plugin.components.toolWindow.components.cycodeActionToolBar.actions
+
+import com.cycode.plugin.CycodeBundle
+import com.cycode.plugin.components.openURL
+import com.cycode.plugin.components.toolWindow.CycodeContentTab
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import java.util.function.Supplier
+
+class HelpAction :
+    DumbAwareAction(Supplier { CycodeBundle.message("toolbarHelpAction") }, AllIcons.Actions.Help) {
+    companion object {
+        fun create(contentTab: CycodeContentTab): HelpAction {
+            return HelpAction()
+        }
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        openURL(CycodeBundle.message("docsUrl"))
+    }
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabled = e.project != null && !e.project!!.isDisposed
+    }
+}

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/HomeAction.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/HomeAction.kt
@@ -1,0 +1,27 @@
+package com.cycode.plugin.components.toolWindow.components.cycodeActionToolBar.actions
+
+import com.cycode.plugin.CycodeBundle
+import com.cycode.plugin.components.toolWindow.CycodeContentTab
+import com.cycode.plugin.components.toolWindow.getRightPanelDependingOnState
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import java.util.function.Supplier
+
+class HomeAction(private val contentTab: CycodeContentTab) :
+    DumbAwareAction(Supplier { CycodeBundle.message("toolbarHomeAction") }, AllIcons.Actions.Back) {
+    companion object {
+        fun create(contentTab: CycodeContentTab): HomeAction {
+            return HomeAction(contentTab)
+        }
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val initRightPanel = getRightPanelDependingOnState(e.project!!)
+        contentTab.updateContent(initRightPanel)
+    }
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabled = e.project != null && !e.project!!.isDisposed
+    }
+}

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/RunAllAction.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/RunAllAction.kt
@@ -1,0 +1,34 @@
+package com.cycode.plugin.components.toolWindow.components.cycodeActionToolBar.actions
+
+import com.cycode.plugin.CycodeBundle
+import com.cycode.plugin.components.toolWindow.CycodeContentTab
+import com.cycode.plugin.services.cycode
+import com.cycode.plugin.services.pluginState
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.project.DumbAwareAction
+import java.util.function.Supplier
+
+class RunAllAction :
+    DumbAwareAction(Supplier { CycodeBundle.message("toolbarRunAllAction") }, AllIcons.Actions.RunAll) {
+    companion object {
+        fun create(contentTab: CycodeContentTab): RunAllAction {
+            return RunAllAction()
+        }
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        // TODO(MarshalX): we should tracks all running scans and use pub-sub messaging to update UI
+        //  we can provide "stop" action only after that
+        val project = e.project ?: return
+        val service = cycode(project)
+        service.startSecretScanForCurrentProject()
+        service.startScaScanForCurrentProject()
+    }
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabled = e.project != null &&
+                !e.project!!.isDisposed &&
+                pluginState().cliAuthed
+    }
+}

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/SettingsAction.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/cycodeActionToolBar/actions/SettingsAction.kt
@@ -1,0 +1,30 @@
+package com.cycode.plugin.components.toolWindow.components.cycodeActionToolBar.actions
+
+import com.cycode.plugin.CycodeBundle
+import com.cycode.plugin.components.toolWindow.CycodeContentTab
+import com.cycode.plugin.settings.ApplicationSettingsConfigurable
+import com.intellij.icons.AllIcons
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.options.ShowSettingsUtil
+import com.intellij.openapi.project.DumbAwareAction
+import java.util.function.Supplier
+
+class SettingsAction :
+    DumbAwareAction(Supplier { CycodeBundle.message("toolbarSettingsAction") }, AllIcons.General.GearPlain) {
+    companion object {
+        fun create(contentTab: CycodeContentTab): SettingsAction {
+            return SettingsAction()
+        }
+    }
+
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        ShowSettingsUtil.getInstance().showSettingsDialog(
+            project, ApplicationSettingsConfigurable::class.java
+        )
+    }
+
+    override fun update(e: AnActionEvent) {
+        e.presentation.isEnabled = e.project != null && !e.project!!.isDisposed
+    }
+}

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/treeView/TreeView.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/treeView/TreeView.kt
@@ -8,9 +8,11 @@ import com.cycode.plugin.cli.models.scanResult.ScanResultBase
 import com.cycode.plugin.cli.models.scanResult.sca.ScaDetection
 import com.cycode.plugin.cli.models.scanResult.secret.SecretDetection
 import com.cycode.plugin.components.toolWindow.components.scaViolationCardContentTab.ScaViolationCardContentTab
+import com.cycode.plugin.components.toolWindow.components.scanContentTab.ScanContentTab
 import com.cycode.plugin.components.toolWindow.components.treeView.components.detectionNodeContextMenu.DetectionNodeContextMenu
 import com.cycode.plugin.components.toolWindow.components.treeView.nodes.*
 import com.cycode.plugin.icons.PluginIcons
+import com.cycode.plugin.services.cycode
 import com.cycode.plugin.services.scanResults
 import com.intellij.openapi.project.Project
 import com.intellij.ui.JBColor
@@ -37,6 +39,7 @@ class TreeView(
     val project: Project, defaultRightPane: JComponent? = null
 ) : JPanel(GridLayout(1, 0)), TreeSelectionListener {
     private val tree: Tree
+    private val service = cycode(project)
 
     // dummyRootNode is a workaround to allow us to hide the root node of the tree
     private val dummyRootNode = createNode(DummyNode())
@@ -83,6 +86,7 @@ class TreeView(
 
         if (node.userObject is SecretDetectionNode) {
             openSecretDetectionInFile(project, node.userObject as SecretDetectionNode)
+            displaySecretViolationCard(node.userObject as SecretDetectionNode)
         }
 
         if (node.userObject is ScaDetectionNode) {
@@ -106,6 +110,12 @@ class TreeView(
                 }
             }
         }
+    }
+
+    fun displaySecretViolationCard(node: SecretDetectionNode) {
+        // we don't have a dedicated card yet for secret violations,
+        // so we are returning to the main content tab
+        replaceRightPanel(ScanContentTab().getContent(service))
     }
 
     fun displayScaViolationCard(node: ScaDetectionNode) {

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/treeView/components/detectionNodeContextMenu/DetectionNodeContextMenu.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/treeView/components/detectionNodeContextMenu/DetectionNodeContextMenu.kt
@@ -98,12 +98,12 @@ class DetectionNodeContextMenu(
 
     private fun onOpenViolationCardOptionClicked() {
         val node = getUnknownNode()
-        if (node !is ScaDetectionNode) {
-            // remove to implement more cards
-            return
+        if (node is ScaDetectionNode) {
+            treeView.displayScaViolationCard(node)
         }
-
-        treeView.displayScaViolationCard(node)
+        if (node is SecretDetectionNode) {
+            treeView.displaySecretViolationCard(node)
+        }
     }
 
     fun showPopup(e: MouseEvent) {

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/treeView/nodes/RootNodes.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/treeView/nodes/RootNodes.kt
@@ -56,6 +56,12 @@ class RootNodes {
         sastNode.removeAllChildren()
         iacNode.removeAllChildren()
 
+        // reset summary to default
+        setNodeSummary(CliScanType.Secret, CycodeBundle.message("secretNodeSummary"))
+        setNodeSummary(CliScanType.Sca, CycodeBundle.message("scaNodeSummary"))
+        setNodeSummary(CliScanType.Sast, CycodeBundle.message("sastNodeSummary"))
+        setNodeSummary(CliScanType.Iac, CycodeBundle.message("iacNodeSummary"))
+
         // the order of adding nodes is important
         top.add(secretNode)
         top.add(scaNode)

--- a/src/main/kotlin/com/cycode/plugin/icons/PluginIcons.kt
+++ b/src/main/kotlin/com/cycode/plugin/icons/PluginIcons.kt
@@ -32,4 +32,14 @@ object PluginIcons {
     private fun intellijLoad(path: String): Icon {
         return IconLoader.getIcon(path, AllIcons::class.java)
     }
+
+    fun getSeverityIcon(severity: String): Icon {
+        return when (severity.toLowerCase()) {
+            "critical" -> SEVERITY_CRITICAL
+            "high" -> SEVERITY_HIGH
+            "medium" -> SEVERITY_MEDIUM
+            "low" -> SEVERITY_LOW
+            else -> SEVERITY_INFO
+        }
+    }
 }

--- a/src/main/resources/messages/CycodeBundle.properties
+++ b/src/main/resources/messages/CycodeBundle.properties
@@ -94,3 +94,9 @@ scaViolationCardHeaderDependencyPathField=Dependency path:
 scaViolationCardHeaderLicenseField=License:
 scaViolationCardHeaderLicenseDefaultValue=Unknown
 scaViolationCardSummaryTitle=Summary
+# toolbar
+toolbarId=CycodeToolbar
+toolbarSettingsAction=Cycode Settings
+toolbarHomeAction=Return to Home Screen
+toolbarFilterBySeverityAction=Filter by {0} severity
+toolbarClearAction=Clear results

--- a/src/main/resources/messages/CycodeBundle.properties
+++ b/src/main/resources/messages/CycodeBundle.properties
@@ -1,5 +1,6 @@
 # general
 name=Cycode
+docsUrl=https://github.com/cycodehq/intellij-platform-plugin/blob/main/README.md
 # detection titles
 secretsTitle={0}. {1}
 secretsNodeTitle=line {0}: a hardcoded {1} is used
@@ -100,3 +101,5 @@ toolbarSettingsAction=Cycode Settings
 toolbarHomeAction=Return to Home Screen
 toolbarFilterBySeverityAction=Filter by {0} severity
 toolbarClearAction=Clear results
+toolbarHelpAction=Open documentation
+toolbarRunAllAction=Run all scans types for the entire project


### PR DESCRIPTION
DEMO (vertical panel at left top):
<img width="716" alt="image" src="https://github.com/cycodehq/intellij-platform-plugin/assets/15520314/8c7f5584-69eb-4cee-b687-a16343f92c50">

done:
- back to main window (AKA close SCA violation card)
- run all scans for current project
- expand all tree nodes
- collapse all tree nodes
- filter by severity (all enabled by default)
- clear scan results
- open cycode plugin settings
- open docs

leftovers:
- stop ran scans. it requires implementing of scans tracking from plugin's side and implementing messaging infrastructure
