### PR TITLE
CM-35352 - Add intention action to open violation card

### DIFF
--- a/src/main/kotlin/com/cycode/plugin/annotators/annotationAppliers/IacApplier.kt
+++ b/src/main/kotlin/com/cycode/plugin/annotators/annotationAppliers/IacApplier.kt
@@ -7,6 +7,7 @@ import com.cycode.plugin.cli.CliResult
 import com.cycode.plugin.cli.CliScanType
 import com.cycode.plugin.intentions.CycodeIgnoreIntentionQuickFix
 import com.cycode.plugin.intentions.CycodeIgnoreType
+import com.cycode.plugin.intentions.CycodeOpenViolationCardIntentionQuickFix
 import com.cycode.plugin.services.ScanResultsService
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.openapi.util.TextRange
@@ -60,6 +61,7 @@ class IacApplier(private val scanResults: ScanResultsService) : AnnotationApplie
             holder.newAnnotation(severity, title)
                 .range(textRange)
                 .tooltip(tooltip)
+                .withFix(CycodeOpenViolationCardIntentionQuickFix(detection))
                 .withFix(
                     CycodeIgnoreIntentionQuickFix(
                         CliScanType.Iac,

--- a/src/main/kotlin/com/cycode/plugin/annotators/annotationAppliers/SastApplier.kt
+++ b/src/main/kotlin/com/cycode/plugin/annotators/annotationAppliers/SastApplier.kt
@@ -7,6 +7,7 @@ import com.cycode.plugin.cli.CliResult
 import com.cycode.plugin.cli.CliScanType
 import com.cycode.plugin.intentions.CycodeIgnoreIntentionQuickFix
 import com.cycode.plugin.intentions.CycodeIgnoreType
+import com.cycode.plugin.intentions.CycodeOpenViolationCardIntentionQuickFix
 import com.cycode.plugin.services.ScanResultsService
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.openapi.util.TextRange
@@ -57,6 +58,7 @@ class SastApplier(private val scanResults: ScanResultsService) : AnnotationAppli
             holder.newAnnotation(severity, title)
                 .range(textRange)
                 .tooltip(tooltip)
+                .withFix(CycodeOpenViolationCardIntentionQuickFix(detection))
                 .withFix(
                     CycodeIgnoreIntentionQuickFix(
                         CliScanType.Sast,

--- a/src/main/kotlin/com/cycode/plugin/annotators/annotationAppliers/ScaApplier.kt
+++ b/src/main/kotlin/com/cycode/plugin/annotators/annotationAppliers/ScaApplier.kt
@@ -9,6 +9,7 @@ import com.cycode.plugin.cli.getPackageFileForLockFile
 import com.cycode.plugin.cli.isSupportedLockFile
 import com.cycode.plugin.intentions.CycodeIgnoreIntentionQuickFix
 import com.cycode.plugin.intentions.CycodeIgnoreType
+import com.cycode.plugin.intentions.CycodeOpenViolationCardIntentionQuickFix
 import com.cycode.plugin.services.ScanResultsService
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.openapi.diagnostic.thisLogger
@@ -88,6 +89,7 @@ class ScaApplier(private val scanResults: ScanResultsService) : AnnotationApplie
             holder.newAnnotation(severity, title)
                 .range(textRange)
                 .tooltip(tooltip)
+                .withFix(CycodeOpenViolationCardIntentionQuickFix(detection))
                 .withFix(
                     CycodeIgnoreIntentionQuickFix(
                         CliScanType.Sca,

--- a/src/main/kotlin/com/cycode/plugin/annotators/annotationAppliers/SecretApplier.kt
+++ b/src/main/kotlin/com/cycode/plugin/annotators/annotationAppliers/SecretApplier.kt
@@ -7,6 +7,7 @@ import com.cycode.plugin.cli.CliResult
 import com.cycode.plugin.cli.CliScanType
 import com.cycode.plugin.intentions.CycodeIgnoreIntentionQuickFix
 import com.cycode.plugin.intentions.CycodeIgnoreType
+import com.cycode.plugin.intentions.CycodeOpenViolationCardIntentionQuickFix
 import com.cycode.plugin.services.ScanResultsService
 import com.intellij.lang.annotation.AnnotationHolder
 import com.intellij.openapi.diagnostic.thisLogger
@@ -71,6 +72,7 @@ class SecretApplier(private val scanResults: ScanResultsService) : AnnotationApp
             holder.newAnnotation(severity, title)
                 .range(textRange)
                 .tooltip(tooltip)
+                .withFix(CycodeOpenViolationCardIntentionQuickFix(detection))
                 .withFix(
                     CycodeIgnoreIntentionQuickFix(
                         CliScanType.Secret,

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/CycodeToolWindowFactory.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/CycodeToolWindowFactory.kt
@@ -1,5 +1,6 @@
 package com.cycode.plugin.components.toolWindow
 
+import com.cycode.plugin.CycodeBundle
 import com.cycode.plugin.components.toolWindow.components.authContentTab.AuthContentTab
 import com.cycode.plugin.components.toolWindow.components.cycodeActionToolBar.CycodeActionToolbar
 import com.cycode.plugin.components.toolWindow.components.loadingContentTab.LoadingContentTab
@@ -15,6 +16,7 @@ import com.intellij.openapi.project.ProjectManager
 import com.intellij.openapi.util.Disposer
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.openapi.wm.ToolWindowManager
 import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentFactory
 import javax.swing.JPanel
@@ -104,4 +106,10 @@ fun updateToolWindowState(project: Project) {
             replaceToolWindowRightPanel(project, getRightPanelDependingOnState(project))
         }
     }
+}
+
+fun activateToolWindow(project: Project) {
+    val toolWindowManager = ToolWindowManager.getInstance(project)
+    val toolWindow = toolWindowManager.getToolWindow(CycodeBundle.message("toolWindowId"))
+    toolWindow?.activate(null)
 }

--- a/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/treeView/TreeView.kt
+++ b/src/main/kotlin/com/cycode/plugin/components/toolWindow/components/treeView/TreeView.kt
@@ -108,11 +108,21 @@ class TreeView(
     }
 
     fun displayViolationCard(node: AbstractNode) {
-        val card = when (node) {
-            is SecretDetectionNode -> SecretViolationCardContentTab().getContent(node.detection)
-            is ScaDetectionNode -> ScaViolationCardContentTab().getContent(node.detection)
-            is IacDetectionNode -> IacViolationCardContentTab().getContent(node.detection)
-            is SastDetectionNode -> SastViolationCardContentTab().getContent(node.detection)
+        when (node) {
+            is SecretDetectionNode -> displayViolationCard(node.detection)
+            is ScaDetectionNode -> displayViolationCard(node.detection)
+            is IacDetectionNode -> displayViolationCard(node.detection)
+            is SastDetectionNode -> displayViolationCard(node.detection)
+            else -> return
+        }
+    }
+
+    fun displayViolationCard(detection: DetectionBase) {
+        val card = when (detection) {
+            is SecretDetection -> SecretViolationCardContentTab().getContent(detection)
+            is ScaDetection -> ScaViolationCardContentTab().getContent(detection)
+            is IacDetection -> IacViolationCardContentTab().getContent(detection)
+            is SastDetection -> SastViolationCardContentTab().getContent(detection)
             else -> return
         }
 

--- a/src/main/kotlin/com/cycode/plugin/intentions/CycodeIgnoreIntentionQuickFix.kt
+++ b/src/main/kotlin/com/cycode/plugin/intentions/CycodeIgnoreIntentionQuickFix.kt
@@ -1,5 +1,6 @@
 package com.cycode.plugin.intentions
 
+import com.cycode.plugin.CycodeBundle
 import com.cycode.plugin.cli.CliScanType
 import com.cycode.plugin.components.toolWindow.updateToolWindowState
 import com.cycode.plugin.services.cycode
@@ -14,12 +15,6 @@ import com.intellij.openapi.util.Iconable
 import com.intellij.psi.PsiFile
 import javax.swing.Icon
 
-enum class CycodeIgnoreType {
-    VALUE,
-    RULE,
-    PATH
-}
-
 
 class CycodeIgnoreIntentionQuickFix(
     private val scanType: CliScanType,
@@ -30,15 +25,15 @@ class CycodeIgnoreIntentionQuickFix(
     override fun getText(): String {
         with(type) {
             return when (this) {
-                CycodeIgnoreType.VALUE -> "Ignore value '$value'"
-                CycodeIgnoreType.RULE -> "Ignore rule '$value'"
-                CycodeIgnoreType.PATH -> "Ignore path '$value'"
+                CycodeIgnoreType.VALUE -> CycodeBundle.message("ignoreIntentionByValueText", value)
+                CycodeIgnoreType.RULE -> CycodeBundle.message("ignoreIntentionByRuleText", value)
+                CycodeIgnoreType.PATH -> CycodeBundle.message("ignoreIntentionByPathText", value)
             }
         }
     }
 
     override fun getFamilyName(): String {
-        return "Ignore"
+        return CycodeBundle.message("ignoreIntentionFamilyName")
     }
 
     override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {

--- a/src/main/kotlin/com/cycode/plugin/intentions/CycodeIgnoreType.kt
+++ b/src/main/kotlin/com/cycode/plugin/intentions/CycodeIgnoreType.kt
@@ -1,0 +1,7 @@
+package com.cycode.plugin.intentions
+
+enum class CycodeIgnoreType {
+    VALUE,
+    RULE,
+    PATH
+}

--- a/src/main/kotlin/com/cycode/plugin/intentions/CycodeOpenViolationCardIntentionQuickFix.kt
+++ b/src/main/kotlin/com/cycode/plugin/intentions/CycodeOpenViolationCardIntentionQuickFix.kt
@@ -1,0 +1,52 @@
+package com.cycode.plugin.intentions
+
+import com.cycode.plugin.CycodeBundle
+import com.cycode.plugin.cli.models.scanResult.DetectionBase
+import com.cycode.plugin.components.toolWindow.CycodeToolWindowFactory
+import com.cycode.plugin.components.toolWindow.activateToolWindow
+import com.intellij.codeInsight.intention.PriorityAction
+import com.intellij.codeInsight.intention.impl.BaseIntentionAction
+import com.intellij.openapi.diagnostic.thisLogger
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.util.Iconable
+import com.intellij.psi.PsiFile
+import javax.swing.Icon
+
+
+class CycodeOpenViolationCardIntentionQuickFix(
+    private val detection: DetectionBase,
+) :
+    BaseIntentionAction(), PriorityAction, Iconable {
+    override fun getText(): String {
+        return CycodeBundle.message("violationCardIntentionText", detection.getFormattedNodeTitle())
+    }
+
+    override fun getFamilyName(): String {
+        return CycodeBundle.message("violationCardIntentionFamilyName")
+    }
+
+    override fun isAvailable(project: Project, editor: Editor?, file: PsiFile?): Boolean {
+        return true
+    }
+
+    override fun invoke(project: Project, editor: Editor?, file: PsiFile?) {
+        if (file == null || file != file.originalFile) {
+            // Disable Intention Action Preview
+            return
+        }
+
+        thisLogger().warn("Open violation card quick fix intention has been invoked")
+
+        CycodeToolWindowFactory.TabManager.getTab(project)?.getTreeView()?.displayViolationCard(detection)
+        activateToolWindow(project)
+    }
+
+    override fun getPriority(): PriorityAction.Priority {
+        return PriorityAction.Priority.NORMAL
+    }
+
+    override fun getIcon(flags: Int): Icon {
+        return com.intellij.icons.AllIcons.Actions.IntentionBulbGrey
+    }
+}

--- a/src/main/kotlin/com/cycode/plugin/utils/CycodeNotifier.kt
+++ b/src/main/kotlin/com/cycode/plugin/utils/CycodeNotifier.kt
@@ -1,21 +1,19 @@
 package com.cycode.plugin.utils
 
 import com.cycode.plugin.CycodeBundle
+import com.cycode.plugin.components.toolWindow.activateToolWindow
 import com.intellij.notification.NotificationGroup
 import com.intellij.notification.NotificationGroupManager
 import com.intellij.notification.NotificationType
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.project.Project
-import com.intellij.openapi.wm.ToolWindowManager
 
 
 class OpenProblemsTabAction : AnAction(CycodeBundle.message("openProblemsTabAction")) {
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        val toolWindowManager = ToolWindowManager.getInstance(project)
-        val toolWindow = toolWindowManager.getToolWindow(CycodeBundle.message("toolWindowId"))
-        toolWindow?.activate(null)
+        activateToolWindow(project)
     }
 }
 

--- a/src/main/resources/messages/CycodeBundle.properties
+++ b/src/main/resources/messages/CycodeBundle.properties
@@ -18,6 +18,13 @@ scaAnnotationTooltipFirstPatchedVersion=First patched version: {0}<br>
 scaAnnotationTooltipLockFileNote=<br><br>Avoid manual packages upgrades in lock files. Update the {0} file and re-generate the lock file.
 iacAnnotationTooltip=<html>Severity: {0}<br>Description: {1}<br>IaC Provider: {2}<br>In file: {3}</html>
 sastAnnotationTooltip=<html>Severity: {0}<br>Description: {1}<br>In file: {2}</html>
+# intention actions
+ignoreIntentionFamilyName=Ignore
+ignoreIntentionByValueText=Ignore value ''{0}''
+ignoreIntentionByRuleText=Ignore rule ''{0}''
+ignoreIntentionByPathText=Ignore path ''{0}''
+violationCardIntentionFamilyName=Open Violation Card
+violationCardIntentionText=Open Violation Card for ''{0}''
 # notifications
 notificationGroupId=Cycode
 notificationTitle=Cycode


### PR DESCRIPTION
DEMO:

<img width="865" alt="image" src="https://github.com/cycodehq/intellij-platform-plugin/assets/15520314/70c5e05e-9969-4069-acae-56920dbcaa28">

<img width="888" alt="image" src="https://github.com/cycodehq/intellij-platform-plugin/assets/15520314/b5568ca5-5546-4b92-ac4e-87ea2102c864">


notes:
1. if cycode tool window is closed, it will open it
2. the current action label contains duplicates in SCA module (which de-duplicates by IDE API)
3. we should choose a better action label

there is only 1 requirement for the label: it **must be unique** per detection