### PR TITLE
CM-43972 - Add support for IDEs 2025.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+## [2.4.0] - 2025-01-20
+
+- Add support for IDEs 2025.1
+
 ## [2.3.0] - 2024-12-20
 
 - Add the "Ignore this violation" button for violation card of SCA
@@ -135,6 +139,8 @@
 
 The first public release of the plugin.
 
+[2.4.0]: https://github.com/cycodehq/intellij-platform-plugin/releases/tag/v2.4.0
+
 [2.3.0]: https://github.com/cycodehq/intellij-platform-plugin/releases/tag/v2.3.0
 
 [2.2.0]: https://github.com/cycodehq/intellij-platform-plugin/releases/tag/v2.2.0
@@ -189,4 +195,4 @@ The first public release of the plugin.
 
 [1.0.0]: https://github.com/cycodehq/intellij-platform-plugin/releases/tag/v1.0.0
 
-[Unreleased]: https://github.com/cycodehq/intellij-platform-plugin/compare/v2.3.0...HEAD
+[Unreleased]: https://github.com/cycodehq/intellij-platform-plugin/compare/v2.4.0...HEAD

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,11 +4,11 @@ pluginGroup = com.cycode.plugin
 pluginName = Cycode
 pluginRepositoryUrl = https://github.com/cycodehq/intellij-platform-plugin
 # SemVer format -> https://semver.org
-pluginVersion = 2.3.0
+pluginVersion = 2.4.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 231
-pluginUntilBuild = 243.*
+pluginUntilBuild = 251.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC


### PR DESCRIPTION
Verification results

Prev (IC-243.23654.117):
<img width="2227" alt="image" src="https://github.com/user-attachments/assets/ffba9cfe-1a25-425b-93f3-4bfe5f30129d" />

New (IC-251.14649.49):
<img width="2229" alt="image" src="https://github.com/user-attachments/assets/e2121417-3a27-448c-a609-5d27df56c54c" />

summary: passed; somehow methods of error handler now marked with "it is internal" annotation