### PR TITLE
CM-62296: Add IntelliJ IDEA 2026.1 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation(libs.flexmark)
 
     intellijPlatform {
-        intellijIdea(properties("platformVersion"))
+        intellijIdeaCommunity(properties("platformVersion"))
         // Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
         // Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
         bundledPlugin("com.intellij.java")
@@ -150,11 +150,6 @@ tasks {
             )
         }
     }
-}
-
-val runIde2026 by intellijPlatformTesting.runIde.registering {
-    useInstaller = false
-    localPath = file("/Applications/IntelliJ IDEA.app")
 }
 
 val runIdeForUiTests by intellijPlatformTesting.runIde.registering {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
     implementation(libs.flexmark)
 
     intellijPlatform {
-        intellijIdeaCommunity(properties("platformVersion"))
+        intellijIdea(properties("platformVersion"))
         // Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
         // Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
         bundledPlugin("com.intellij.java")
@@ -150,6 +150,11 @@ tasks {
             )
         }
     }
+}
+
+val runIde2026 by intellijPlatformTesting.runIde.registering {
+    useInstaller = false
+    localPath = file("/Applications/IntelliJ IDEA.app")
 }
 
 val runIdeForUiTests by intellijPlatformTesting.runIde.registering {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,7 @@ pluginUntilBuild = 263.*
 # 2022.3 - minimum version for IntelliJ Platform Gradle Plugin (2.x)
 # 2023.1 - allows to fix "com.intellij.diagnostic.PluginException: `ActionUpdateThread.OLD_EDT` is deprecated blabla"
 # 2024.1 - allows to fix "com.cycode.plugin.services.ServicesKt" compatibility issues
-platformVersion = 2025.3
+platformVersion = 2024.1
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 9.4.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,17 +8,17 @@ pluginVersion = 3.0.4
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 241
-pluginUntilBuild = 253.*
+pluginUntilBuild = 263.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin.html
 # 2021.1 - Apple Silicon support + fixes for development on Apple Silicon
 # 2022.3 - minimum version for IntelliJ Platform Gradle Plugin (2.x)
 # 2023.1 - allows to fix "com.intellij.diagnostic.PluginException: `ActionUpdateThread.OLD_EDT` is deprecated blabla"
 # 2024.1 - allows to fix "com.cycode.plugin.services.ServicesKt" compatibility issues
-platformVersion = 2024.1
+platformVersion = 2025.3
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.14.1
+gradleVersion = 9.4.1
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,8 +8,8 @@ flexmark = "0.64.8"
 dokka = "1.9.20"
 kotlin = "2.2.0"
 changelog = "2.2.1"
-gradleIntelliJPlugin = "2.10.4"
-kover = "0.9.0"
+gradleIntelliJPlugin = "2.13.1"
+kover = "0.9.8"
 
 [libraries]
 annotations = { group = "org.jetbrains", name = "annotations", version.ref = "annotations" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- Bumps `pluginUntilBuild` from `253.*` to `263.*` to support IntelliJ IDEA 2026.x
- Upgrades IntelliJ Platform Gradle Plugin to 2.13.1, which supports the new unified IntelliJ IDEA distribution introduced in 2025.3 (Community and Ultimate merged into one product)
- Upgrades Gradle to 9.4.1 and Kover to 0.9.8 to satisfy the new plugin requirements
- Switches from `intellijIdeaCommunity()` to `intellijIdea()` and bumps `platformVersion` to `2025.3`, as separate Community/Ultimate distributions no longer exist from 2025.3 onwards
- Adds a `runIde2026` Gradle task for local testing against a locally installed 2026.1 IDE

## Test plan
- [ ] CI `verifyPlugin` task passes against all recommended IDEs including 2026.1 (now included automatically via `recommended()`)
- [ ] Plugin builds successfully with `./gradlew buildPlugin`
- [ ] Local run with `./gradlew runIde2026` works when IntelliJ IDEA 2026.1 is installed at `/Applications/IntelliJ IDEA.app`

🤖 Generated with [Claude Code](https://claude.com/claude-code)